### PR TITLE
Fix the showPrevNext method

### DIFF
--- a/addon/components/ui-pagination/component.js
+++ b/addon/components/ui-pagination/component.js
@@ -84,7 +84,7 @@ export default Ember.Component.extend({
     }
   }),
 
-  showPrevNext: computed('totalCount', {
+  showPrevNext: computed('totalCount', 'perPage', {
     get(){
       // A condition to check if the Pagination component needs to be rendered or not.
       return (this.get('totalCount') > this.get('perPage'));


### PR DESCRIPTION
_Bug:_
**showPrevNext** computed property is only observing **totalCount**. So when we change the **perPage** (i.e. no of records per page) it will not be recomputed again.

_Fix:_
Make **showPrevNext** observe **perPage** also.